### PR TITLE
Added missing SdFat submodule to libraries folder.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "libraries/SparkFun_MPL3115A2"]
 	path = libraries/SparkFun_MPL3115A2
 	url = https://github.com/sparkfun/SparkFun_MPL3115A2_Breakout_Arduino_Library
+[submodule "libraries/SdFat"]
+	path = libraries/SdFat
+	url = https://github.com/greiman/SdFat


### PR DESCRIPTION
This repo does not currently compile out of a fresh clone. This pull requests adds the missing SdFat submodule to the repository, and gets us a step closer to out of the repo compilation.