### PR TITLE
Add Forked Adafruit_INA219 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/JChristensen/DS3232RTC
 [submodule "libraries/Adafruit_INA219"]
 	path = libraries/Adafruit_INA219
-	url = https://github.com/adafruit/Adafruit_INA219
+	url = https://github.com/crestlinesoaring/Adafruit_INA219
 [submodule "libraries/SparkFun_BME280"]
 	path = libraries/SparkFun_BME280
 	url = https://github.com/sparkfun/SparkFun_BME280_Arduino_Library


### PR DESCRIPTION
@lrocker @CSSMWX  The purpose of this pull request is mostly housekeeping. We required a way to share the 5 Amp version of the Adafruit_INA219 library within the management of our source code. This was accomplished via the following:

1. Fork the original Repo (which is owned by CrestlineSoaring):
https://github.com/crestlinesoaring/Adafruit_INA219
Note: I gave @lrocker  and myself write permissions to the fork.

2. Update the forked repo with the 5 Amp modifications we made to the library.

3. Alter the submodule url to point to our new Fork.

4. Sync the Adafruit_INA219 submodule to point the latest commit in our fork. 
```
git submodule sync 
```

```C
/* Updates all submodules to the latest commit of their respective repos. */
git submodule update --recursive --remote
```

I learned 2 things we should consider:

1. Our submodule list is static, and we can occasionally choose to update to the latest commit of the libraries we are referencing.

2. There are other options besides forking if we believe this to be too heavy handed, but I found it to be the best way in case there are other modifications required to the library in the future.

